### PR TITLE
Properly namespace ValidationError.

### DIFF
--- a/DjangoProject/HvZ/forms.py
+++ b/DjangoProject/HvZ/forms.py
@@ -111,7 +111,7 @@ class FeedCodeField(forms.CharField):
         feedCode = feedCode.upper()
         for letter in feedCode:
             if letter not in self.validLetters:
-                raise ValidationError(letter + " is not one of the valid letters!")
+                raise forms.ValidationError(letter + " is not a valid feed code letter.")
         return feedCode
 
 


### PR DESCRIPTION
Now the RegForm won't crash as soon as someone inputs a bad feed code.

This fixes issue #47.
