### PR TITLE
Remove uppercasing.

### DIFF
--- a/DjangoProject/HvZ/forms.py
+++ b/DjangoProject/HvZ/forms.py
@@ -108,11 +108,11 @@ class FeedCodeField(forms.CharField):
         return ', '.join(self.validLetters)
 
     def validate(self, feedCode):
-        feedCode = feedCode.upper()
+        """Feed Codes can only contain the given subset of letters."""
+        super(FeedCodeField, self).validate(feedCode)
         for letter in feedCode:
             if letter not in self.validLetters:
                 raise forms.ValidationError(letter + " is not a valid feed code letter.")
-        return feedCode
 
 
 class RegForm(forms.Form):


### PR DESCRIPTION
I thought validate cleaned the value and returned it --- not so. The original validate method allowed lowercase feed codes to sneak in there... we also need model level validation at some point.
