### PR TITLE
Remove silent replacement.

### DIFF
--- a/DjangoProject/HvZ/views.py
+++ b/DjangoProject/HvZ/views.py
@@ -186,12 +186,7 @@ def get_on_duty():
 		return {"name": "apparently no one", "cell": "N/A"}
 
 def clean_feed_code(inputString):
-	replacements = [("B", "A"), ("H", "A"), ("G","C"), ("F","E"), ("I","L"), ("M","N"), ("D","O"), ("Q","O"), ("R","P"), ("J","T"), ("U","W"), ("V","W"), ("K","X"), ("Y","X")]
-	output = inputString
-	for old, new in replacements:
-		output = output.replace(old, new)
-	output = output.upper()
-	return output
+	return inputString.upper()
 
 
 def log_user_in(request):


### PR DESCRIPTION
At the moment, the website replaces characters not in the feed code alphabet with characters in the feed code alphabet. These replacements are entirely arbitrary. I don't believe we should be making this call for the user, nor is this a particularly DRY way of doing things. I propose we remove silent replacement entirely.

This commit would address issue #66.
