### PR TITLE
Fixes/phones

### DIFF
--- a/DjangoProject/HvZ/tests.py
+++ b/DjangoProject/HvZ/tests.py
@@ -58,7 +58,8 @@ class ConfirmTextingWorks(TestCase):
                             })
 
           self.assertEqual(response.status_code, 200)
-     
+          self.assertEqual(response.context['response'],
+                           "Valid commands are status, mod, mission, feed, stop, and help.")
 
 class SimpleTest(TestCase):
     def test_basic_addition(self):

--- a/DjangoProject/HvZ/views.py
+++ b/DjangoProject/HvZ/views.py
@@ -241,7 +241,7 @@ def logout_view(request):
 
 def twilio_to_django(number):
 	"""Convert a phone number from Twilio format to Django's format."""
-	return USPhoneNumberField().clean(number[2:])
+	return USPhoneNumberField().clean(number[1:])
 
 def twilio_call_view(request):
 	od = get_on_duty()


### PR DESCRIPTION
I instantiate a `USPhoneNumberField` just to call its `clean` method, which is rather wasteful. Should I just pass `None` as its `self` argument instead?

I'm also not 100% certain that the Twilio schema is "+11234567890". But I'm still pretty damn sure this will work.

Either way, I believe this commit will fix issue #81.
