### PR TITLE
Stop displaying meals created after the current time.

### DIFF
--- a/DjangoProject/HvZ/views.py
+++ b/DjangoProject/HvZ/views.py
@@ -621,7 +621,7 @@ def meal_histograms(g):
 
 	# Make one query to the database, then drop each meal in its
 	# appropriate bucket.
-	meal_query = Meal.objects.all()
+	meal_query = Meal.objects.exclude(time__gt=datetime.now())
 	for m in meal_query:
 		t = m.time
 		i = elapsed_hours(t, t0)


### PR DESCRIPTION
Aand now we exclude all meals created after the current time. Awesome.

This fixes issue #85.
