### PR TITLE
Merge Player and Registration.

### DIFF
--- a/HVZ/HVZ/main/models.py
+++ b/HVZ/HVZ/main/models.py
@@ -47,18 +47,45 @@ class Building(models.Model):
 
 class Player(models.Model):
     """Game-related data about a user"""
-    user = models.OneToOneField(User)
+
+    TEAMS = {
+        "H": "Humans",
+        "Z": "Zombies",
+    }
+
+    UPGRADES = {}
+    FEED_SZ = 6
+
+    user = models.ForeignKey(User)
+    cell = PhoneNumberField(blank=True, null=True)
+
+    game = models.ForeignKey(Game)
+
     school = models.ForeignKey(School)
     dorm = models.ForeignKey(Building)
-
     grad_year = models.PositiveIntegerField(blank=True, null=True)
 
-    cell = PhoneNumberField(blank=True, null=True)
+    can_oz = models.BooleanField(default=False)
+    can_c3 = models.BooleanField(default=False)
+    hardcore = models.BooleanField(default=False)
+
+    feed = models.CharField(max_length=FEED_SZ)
+
+    team = models.CharField(
+        max_length=1,
+        choices=TEAMS.items(),
+        default="H",
+    )
+
+    upgrade = models.CharField(
+        max_length=1,
+        choices=UPGRADES.items(),
+        blank=True,
+        null=True,
+    )
 
     human_pic = models.ImageField()
     zombie_pic = models.ImageField()
-
-    bad_meals = models.PositiveIntegerField(default=0, blank=False)
 
     def __unicode__(self):
         return u"Player: {}".format(self.user)
@@ -98,48 +125,6 @@ class Game(models.Model):
             self.SEMESTERS[self.semester],
             self.year,
         )
-
-
-class Registration(models.Model):
-    """An instance of a player in a certain game."""
-    TEAMS = {
-        "H": "Humans",
-        "Z": "Zombies",
-    }
-
-    HIDDEN_UPGRADES = {
-        "R": "Rebel Zombie",
-    }
-
-    player = models.ForeignKey(Player)
-    hardcore = models.BooleanField(default=False)
-    feed = models.CharField(max_length=6)
-
-    game = models.ForeignKey(Game)
-    team = models.CharField(
-        max_length=1,
-        choices=[(x, TEAMS[x]) for x in TEAMS],
-        default="H",
-    )
-    can_oz = models.BooleanField(default=False)
-    can_c3 = models.BooleanField(default=False)
-
-    upgrade = models.CharField(
-        max_length=1,
-        choices=[(x, HIDDEN_UPGRADES[x]) for x in HIDDEN_UPGRADES],
-        blank=True,
-        null=True,
-    )
-
-    bonus = models.PositiveIntegerField(default=0, blank=False)
-
-    def __unicode__(self):
-        return u"{}: {} {}".format(
-            self.game,
-            self.player.first_name(),
-            self.player.last_name(),
-        )
-
 
 class Award(models.Model):
     title = models.CharField(max_length=80)


### PR DESCRIPTION
Mostly to see how it looks; it feels simpler this way. Certainly we
won't have to be juggling Players, Users, and Registrations as much
with this setup. We might have redundant data between games (the ImageFields might become a problem over time), but we
won't have to worry about losing information, or the stats rotting
over time.

This is my proposed answer to issue #95 .
