### PR TITLE
Add a calendar widget to choose meal date

### DIFF
--- a/HVZ/HVZ/feed/forms.py
+++ b/HVZ/HVZ/feed/forms.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 
 from HVZ.main.forms import FeedCodeField
@@ -15,7 +17,9 @@ class MealForm(forms.Form):
 
     time = forms.DateTimeField(
         required=False,
+        initial=datetime.datetime.now,
         validators=[TimeValidator()],
+        widget=forms.SplitDateTimeWidget,
     )
 
     location = forms.ModelChoiceField(

--- a/HVZ/HVZ/feed/static/scripts/eat.js
+++ b/HVZ/HVZ/feed/static/scripts/eat.js
@@ -1,0 +1,12 @@
+(function() {
+    "use strict";
+
+    $(function() {
+        // Restrict possible dates to the start of the current game and today.
+        $("#id_time_0").datepicker({
+            minDate: Date.parse($("#game_start")),
+            maxDate: new Date(),
+        });
+    });
+
+})();

--- a/HVZ/HVZ/feed/templates/feed/eat.html
+++ b/HVZ/HVZ/feed/templates/feed/eat.html
@@ -1,8 +1,18 @@
 {% extends "base.html" %}
 
+{% load staticfiles %}
 {% load url from future %}
 
+{% block morehead %}
+<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.0/themes/base/jquery-ui.css" />
+<script type="text/javascript" src="{% static 'scripts/eat.js' %}"></script>
+{% endblock %}
+
 {% block content %}
+<div id="game_start" class="hidden">
+  {{ game_start }}
+</div>
+
 <form method="post" action="{% url 'feed_eat' %}">
   {% csrf_token %}
   {{ form.as_p }}

--- a/HVZ/HVZ/feed/tests.py
+++ b/HVZ/HVZ/feed/tests.py
@@ -33,7 +33,8 @@ VICTIM = define_user({
         })
 
 MEAL = {
-    "time": datetime.now().strftime("%m/%d/%Y %H:%M:%S"),
+    "time_0": datetime.now().strftime("%m/%d/%Y"),
+    "time_1": datetime.now().strftime("%H:%M:%S"),
     "location": "208",
     "description": "I don't want to live on this planet anymore.",
     "feedcode": VICTIM["feed"]
@@ -117,7 +118,7 @@ class EatingTest(BaseTest):
         yesterday = datetime.now() - timedelta(days=1)
 
         m = MEAL.copy()
-        m['time'] = yesterday.strftime("%m/%d/%Y %H:%M:%S")
+        m['time_0'] = yesterday.strftime("%m/%d/%Y")
 
         c = Client()
         c.post(reverse("login"), ROB_ZOMBIE)

--- a/HVZ/HVZ/feed/views.py
+++ b/HVZ/HVZ/feed/views.py
@@ -5,8 +5,9 @@ from django.contrib.auth.decorators import login_required
 
 from HVZ.main.decorators import zombie_required
 
-from models import Meal, Player
+from models import Meal
 from forms import MealForm
+from HVZ.main.models import Player, Game
 
 
 class EatView(FormView):
@@ -20,6 +21,14 @@ class EatView(FormView):
 
     def get_success_url(self):
         return reverse("main_landing")
+
+    def get_context_data(self, **kwargs):
+        context = super(EatView, self).get_context_data(**kwargs)
+        game = Game.nearest_game()
+
+        context['game_start'] = game.start_date
+
+        return context
 
     def form_valid(self, form):
         def grab(s):


### PR DESCRIPTION
I think this makes choosing the date of a meal easier (the time still
needs something, even if that something is just AM and PM). Obviously we
can define more attractive CSS for the calendar.

![eat-screen](https://f.cloud.github.com/assets/887446/130370/9491173e-7017-11e2-8f87-922b2e50b30f.png)
