### PR TITLE
Add customizable ordering to rules.

### DIFF
--- a/HVZ/HVZ/rules/admin.py
+++ b/HVZ/HVZ/rules/admin.py
@@ -1,8 +1,32 @@
+from django import forms
 from django.contrib import admin
 
 from HVZ.rules import models
 
-admin.site.register(models.CoreRule)
-admin.site.register(models.LocationRule)
-admin.site.register(models.ClassRule)
-admin.site.register(models.SpecialInfectedRule)
+
+class RuleForm(forms.ModelForm):
+    model = models.BaseRule
+    exclude = ('position',)
+
+
+class RuleAdmin(admin.ModelAdmin):
+    list_display = ('title', 'position',)
+    list_editable = ('position',)
+
+    class Media:
+        js = (
+            "scripts/jquery.js",
+            "scripts/jquery-ui.js",
+            "scripts/rule-sort.js",
+        )
+
+
+rule_types = (
+    models.CoreRule,
+    models.LocationRule,
+    models.ClassRule,
+    models.SpecialInfectedRule,
+)
+
+for r in rule_types:
+    admin.site.register(r, RuleAdmin)

--- a/HVZ/HVZ/rules/models.py
+++ b/HVZ/HVZ/rules/models.py
@@ -1,12 +1,16 @@
 from django.db import models
 from markupfield import fields
 
+
 class BaseRule(models.Model):
     class Meta:
         abstract = True
+        ordering = ('position',)
 
     title = models.CharField(max_length=100)
-    body = fields.MarkupField()
+    body = fields.MarkupField(default_markup_type='markdown')
+    position = models.PositiveIntegerField(default=0)
+
 
 class CoreRule(BaseRule):
     """Rules that are fundamental to the game."""

--- a/HVZ/HVZ/rules/static/scripts/rule-sort.js
+++ b/HVZ/HVZ/rules/static/scripts/rule-sort.js
@@ -1,0 +1,37 @@
+/**
+ * See http://djangosnippets.org/snippets/1053/
+ */
+
+jQuery(function($) {
+    "use strict";
+
+    var TABLE, POSITION_HEADER, POSITION_INPUT, ROWS;
+
+    TABLE = "#result_list > tbody";
+    POSITION_HEADER = "th:contains('Position')";
+    POSITION_INPUT = "input[id$=position]"
+    ROWS = "#result_list > tbody > tr";
+
+    $(TABLE).sortable({
+        update: function() {
+            $(this).find("tr").each(function(i) {
+
+                // Switch stripes if the row has changed its parity.
+                if (!$(this).hasClass("row" + (i % 2 + 1))) {
+                    $(this).toggleClass("row1 row2");
+                }
+
+                // Update position of each item
+                $(this).find(POSITION_INPUT).val(i+1);
+            });
+
+            // Auto-save
+            $("input[name=_save]").trigger("click")
+        },
+    });
+
+    $(ROWS).css('cursor', 'move');
+    $(POSITION_HEADER).hide();
+    $(POSITION_INPUT).parent().hide();
+    $('div.inline-related').find('input[id$=position]').parent('div').hide();
+});


### PR DESCRIPTION
Uses jQuery-UI for drag-and-drop ordering.

Note that new rules will be dropped in at the beginning by default.

I'm conflicted about auto-save; I put it in because I kept forgetting to click the save button, but it does seem like overkill.

The screenshot doesn't show it, but it does change your cursor into the universal "four-arrow-cross" that tells the user that they can move the objects.
#135

![rule-drag-and-drop](https://f.cloud.github.com/assets/887446/246292/82adc5e2-8a9a-11e2-9192-a8048dda1421.png)
