### PR TITLE
Better Mission/Plot Admin Page

### DIFF
--- a/HVZ/HVZ/missions/admin.py
+++ b/HVZ/HVZ/missions/admin.py
@@ -2,8 +2,27 @@ from django.contrib import admin
 
 from HVZ.missions import models
 
-class PlotAdmin(admin.ModelAdmin):
-    prepopulated_fields = {'slug': ('title',)}
 
-admin.site.register(models.Mission)
-admin.site.register(models.Plot, PlotAdmin)
+class PlotAdminInline(admin.StackedInline):
+    model = models.Plot
+    prepopulated_fields = {'slug': ('title',)}
+    max_num = 2
+    fields = (
+        'title', 'slug', 'team',
+        'before_story', 'victory_story', 'defeat_story',
+        'visible', 'reveal_time',
+    )
+
+
+class MissionAdmin(admin.ModelAdmin):
+    list_filter = ('game',)
+
+    list_display = ('__unicode__', 'victor',)
+    lis_display_links = ('__unicode__',)
+    list_editable = ('victor',)
+
+    inlines = (PlotAdminInline,)
+
+
+admin.site.register(models.Mission, MissionAdmin)
+

--- a/HVZ/HVZ/missions/models.py
+++ b/HVZ/HVZ/missions/models.py
@@ -78,11 +78,18 @@ class Plot(models.Model):
         choices=TEAMS.items(),
     )
 
-    before_story = fields.MarkupField(blank=True, null=True)
-    victory_story = fields.MarkupField(blank=True, null=True)
-    defeat_story = fields.MarkupField(blank=True, null=True)
+    before_story = fields.MarkupField(default_markup_type="markdown", blank=True, null=True)
+    victory_story = fields.MarkupField(default_markup_type="markdown", blank=True, null=True)
+    defeat_story = fields.MarkupField(default_markup_type="markdown", blank=True, null=True)
 
-    visible = models.NullBooleanField()
+    visible = models.NullBooleanField(
+        verbose_name="Visibility Override",
+        choices = (
+            (None, "No Override"),
+            (True, "Force Visible"),
+            (False, "Force Invisible"),
+        )
+    )
     reveal_time = models.DateTimeField(blank=True, null=True)
 
     mission = models.ForeignKey(Mission)


### PR DESCRIPTION
Sliced bread, it's time to meet your reckoning.

Now you can filter missions by game and set a mission's victor or visibility from the mission list!
![mission-list](https://f.cloud.github.com/assets/887446/246686/b77e6df2-8aaa-11e2-9bc3-994ace81108a.png)

You can also define plots inline with missions!
![plot-inlines](https://f.cloud.github.com/assets/887446/246688/ba4e169a-8aaa-11e2-9fcf-d39b9035bf24.png)
