### PR TITLE
Feature/forum permissions

### DIFF
--- a/HVZ/HVZ/forum/management/__init__.py
+++ b/HVZ/HVZ/forum/management/__init__.py
@@ -8,7 +8,7 @@ def create_forums(sender, **kwargs):
     for category_name in settings.CATEGORIES:
         c, created = pybb.models.Category.objects.get_or_create(name=category_name)
         if created:
-            self.stdout.write('Created category "{}"'.format(c.name))
+            print('Created category "{}"'.format(c.name))
 
         for forum_name in settings.FORUMS:
             pybb.models.Forum.objects.get_or_create(category=c, name=forum_name)

--- a/HVZ/HVZ/main/exceptions.py
+++ b/HVZ/HVZ/main/exceptions.py
@@ -1,8 +1,9 @@
-from django.core.exceptions import PermissionDenied, ImproperlyConfigured
+from django.core.exceptions import PermissionDenied
 
 class NoActiveGame(PermissionDenied):
     """Raised when no Game is currently ongoing."""
     pass
 
-class NoUnfinishedGames(ImproperlyConfigured):
+class NoUnfinishedGames(PermissionDenied):
     """Raised when there are no upcoming or current Games."""
+    pass

--- a/HVZ/HVZ/main/models.py
+++ b/HVZ/HVZ/main/models.py
@@ -147,6 +147,14 @@ class Game(models.Model):
         except IndexError:
             raise Game.DoesNotExist
 
+    @classmethod
+    def nearest_game(cls):
+        """Returns the next Game, if one exists. Otherwise returns the last one."""
+        try:
+            return cls.imminent_game()
+        except Game.DoesNotExist:
+            return cls.objects.latest()
+
     class Meta:
         get_latest_by = "start_date"
 

--- a/HVZ/HVZ/missions/views.py
+++ b/HVZ/HVZ/missions/views.py
@@ -21,7 +21,7 @@ class PlotListView(ListView, PlayerAwareMixin):
         return super(PlotListView, self).dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        game = Game.imminent_game()
+        game = Game.nearest_game()
         team = self.player.team
         return Plot.get_visible(game, team).select_related('mission')
 

--- a/HVZ/HVZ/players/views.py
+++ b/HVZ/HVZ/players/views.py
@@ -9,7 +9,7 @@ class PlayerListView(ListView):
     template_name = 'players/player_list.html'
 
     def get_queryset(self):
-        game = Game.imminent_game()
+        game = Game.nearest_game()
         return (Player.objects.filter(game=game).
                 select_related('user').
                 annotate(meal_count=Count('meal_set')))

--- a/HVZ/HVZ/settings.py
+++ b/HVZ/HVZ/settings.py
@@ -229,10 +229,6 @@ VERBOSE_TEAMS = {
     'B': "Both Teams",
 }
 
-# Callables that return the "current" date and time.
-# Can be overridden in local_settings or tests to return a fixed point in time.
-NOW = local_settings.NOW or timezone.now
-
 # The length of a feed code.
 FEED_LEN = 5
 
@@ -262,3 +258,7 @@ PYBB_DEFAULT_MARKUP = None
 PYBB_SIGNATURE_MAX_LENGTH = 50
 PYBB_DEFAULT_TIME_ZONE = -8
 PYBB_PERMISSION_HANDLER = "HVZ.forum.permissions.ForumPermissionHandler"
+
+# Callables that return the "current" date and time.
+# Can be overridden in local_settings or tests to return a fixed point in time.
+NOW = local_settings.NOW or timezone.now

--- a/HVZ/HVZ/stats/views.py
+++ b/HVZ/HVZ/stats/views.py
@@ -57,7 +57,7 @@ class JSONPlayerStats(JSONResponseMixin, BaseListView):
     # def get_context_data(self, *args, **kwargs):
     #     context = super(JSONPlayerStats, self).get_context_data(*args, **kwargs)
 
-    #     context['objects'] = Player.objects.all().filter(game=Game.imminent_game()).values(
+    #     context['objects'] = Player.objects.all().filter(game=Game.nearest_game()).values(
     #         'team',
     #         'grad_year',
     #         'school',
@@ -66,7 +66,7 @@ class JSONPlayerStats(JSONResponseMixin, BaseListView):
 
     #     return context
     def get_queryset(self):
-        return Player.objects.all().filter(game=Game.imminent_game())
+        return Player.objects.all().filter(game=Game.nearest_game())
 
     def raw_serialization(self, context):
         actual = super(JSONPlayerStats, self).raw_serialization(context)


### PR DESCRIPTION
Note that this is in no way a sustainable solution. Forums aren't tied
to games in any way, and permission is based entirely on the string name
of the Forum. If we can inherit from and register a substitute for the
forum class (with actual game logic baked in), I'll be happy to throw
this out.

This commit also creates a `nearest_game` function which gets the latest
game if no imminent game exists; this will allow people to see stats and
player lists after this game is over :whale:

This fixes #150.
