### PR TITLE
Fix issue with long email addresses

### DIFF
--- a/HVZ/HVZ/main/backends.py
+++ b/HVZ/HVZ/main/backends.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+
+class EmailOrUsernameModelBackend(object):
+    """Taken from http://justcramer.com/2008/08/23/logging-in-with-email-addresses-in-django/"""
+
+    def authenticate(self, username=None, password=None):
+        if '@' in username:
+            kwargs = {'email': username}
+        else:
+            kwargs = {'username': username}
+        try:
+            user = User.objects.get(**kwargs)
+            if user.check_password(password):
+                return user
+        except User.DoesNotExist:
+            return None
+
+    def get_user(self, user_id):
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None

--- a/HVZ/HVZ/main/tests.py
+++ b/HVZ/HVZ/main/tests.py
@@ -9,6 +9,7 @@ from django.test.utils import override_settings
 from HVZ.basetest import BaseTest, define_user
 from HVZ.main import models, forms
 
+
 HUGH_MANN = define_user({
         "first_name": "Hugh",
         "last_name": "Mann",
@@ -205,6 +206,31 @@ class SignupTest(BaseTest):
         self.assertEqual(u.first_name, d["first_name"])
         self.assertEqual(u.last_name, d["last_name"])
         self.assertNotEqual(u.password, old_password)
+
+    def test_long_email(self):
+        """Ensure someone with a long email address can register and log in."""
+
+        LONG_EMAIL = "thisisareallylongemailaddress@scrippscollege.edu"
+
+        d = HUGH_MANN.copy()
+        d['email'] = LONG_EMAIL
+
+        # Check assumptions
+        self.assertEqual(models.Player.objects.count(), 0)
+        self.assertEqual(User.objects.count(), 1)
+
+        # Test registration
+        c = Client()
+        self.login_as_tabler(c)
+        response = c.post(reverse('register'), d, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(models.Player.objects.count(), 1)
+        self.assertEqual(User.objects.count(), 2)
+
+        # Test login
+        response = c.post(reverse('login'), d, follow=True)
+        self.assertEqual(response.status_code, 200)
+
 
 class RandomPlayerTest(BaseTest):
 

--- a/HVZ/HVZ/settings.py
+++ b/HVZ/HVZ/settings.py
@@ -172,6 +172,11 @@ MIDDLEWARE_CLASSES = (
     'pybb.middleware.PybbMiddleware',
 )
 
+AUTHENTICATION_BACKENDS = (
+    'HVZ.main.backends.EmailOrUsernameModelBackend',
+    'django.contrib.auth.backends.ModelBackend',
+)
+
 ROOT_URLCONF = 'HVZ.urls'
 AUTH_PROFILE_MODULE = 'pybb.Profile'
 


### PR DESCRIPTION
Note that if two email addresses share the same first 30 characters, the
second will not be allowed to register. We should _actually_ fix this issue before
next game by making a custom User class.

According to the flow model, I think I was supposed to merge this with master. I've seen you merge fixes with develop, though, so w/e.
