### PR TITLE
Changed Link to the Live Update page

### DIFF
--- a/HVZ/HVZ/main/templates/logo.html
+++ b/HVZ/HVZ/main/templates/logo.html
@@ -1,7 +1,7 @@
 {% load staticfiles %}
 <div class="alert alert-danger fade in" role="alert">
       <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
-      <strong>Google Doc:</strong> <a href="https://docs.google.com/document/d/1CXWBrwvWLoMcP5zDgT_4YcB8NfRgo8oK3UMIcmNJ-s4/edit">https://docs.google.com/document/d/1CXWBrwvWLoMcP5zDgT_4YcB8NfRgo8oK3UMIcmNJ-s4/edit</a>
+      <strong>Google Doc:</strong> <a href="https://docs.google.com/document/d/1CXWBrwvWLoMcP5zDgT_4YcB8NfRgo8oK3UMIcmNJ-s4/edit">Live Update Page.</a>
 </div>
 <header class="bar-logo">
   <div class="barholder">


### PR DESCRIPTION
Changed the massive URL link to simply say "Live Update Page".  Still links to the same location.